### PR TITLE
Modified regex handling to use "exact match" in MqttSubscriberManager.cs

### DIFF
--- a/GnatMQ/Managers/MqttSubscriberManager.cs
+++ b/GnatMQ/Managers/MqttSubscriberManager.cs
@@ -63,7 +63,8 @@ namespace uPLibrary.Networking.M2Mqtt.Managers
         public void Subscribe(string topic, byte qosLevel, MqttClient client)
         {
             string topicReplaced = topic.Replace(PLUS_WILDCARD, PLUS_WILDCARD_REPLACE).Replace(SHARP_WILDCARD, SHARP_WILDCARD_REPLACE);
-
+            topicReplaced = "^" + topicReplaced + "$";
+           
             lock (this.subscribers)
             {
                 // if the topic doesn't exist

--- a/GnatMQ/Managers/MqttSubscriberManager.cs
+++ b/GnatMQ/Managers/MqttSubscriberManager.cs
@@ -104,7 +104,8 @@ namespace uPLibrary.Networking.M2Mqtt.Managers
         public void Unsubscribe(string topic, MqttClient client)
         {
             string topicReplaced = topic.Replace(PLUS_WILDCARD, PLUS_WILDCARD_REPLACE).Replace(SHARP_WILDCARD, SHARP_WILDCARD_REPLACE);
-
+            topicReplaced = "^" + topicReplaced + "$";
+           
             lock (this.subscribers)
             {
                 // if the topic exists


### PR DESCRIPTION
Hi,
this should resolve https://github.com/ppatierno/gnatmq/issues/42

Just tried and it's working :octocat: 

What do you think?