### PR TITLE
Fixed collection modified error in foreach loop

### DIFF
--- a/GnatMQ/Managers/MqttPublisherManager.cs
+++ b/GnatMQ/Managers/MqttPublisherManager.cs
@@ -225,8 +225,11 @@ namespace uPLibrary.Networking.M2Mqtt.Managers
 
                         if (query.Count() > 0)
                         {
-                            foreach (MqttMsgPublish retained in query)
+                            // reverse loop to allow for changes in "this.retainedMessages"
+                            for (int i = query.Count() - 1; i >= 0; i--)
                             {
+                                MqttMsgPublish retained = query.ElementAt(i);
+
                                 qosLevel = (subscription.QosLevel < retained.QosLevel) ? subscription.QosLevel : retained.QosLevel;
 
                                 // send PUBLISH message to the current subscriber


### PR DESCRIPTION
Came across an enumeration exception. It occurred when a lot of messages where published in a short space of time from multiple threads. I have a feeling it is caused by the LINQ query execution being deferred.

Whatever the cause; I changed the loop to one which allows the underlying collection to be changed during traversal.
